### PR TITLE
Lead api-use.qmd with HTTP architecture; surface API libraries (closes #3, #4)

### DIFF
--- a/da-knowledge/api-advanced.qmd
+++ b/da-knowledge/api-advanced.qmd
@@ -5,15 +5,7 @@ date: "2025-01-20"
 
 
 
-## HTTP: Client-Server Communication and the Request-Response Cycle
-
-Before diving into APIs, it’s essential to understand how web communication works at its most basic level. The web runs on **HTTP (HyperText Transfer Protocol)**, a simple, text-based language that lets one computer or application (the **client**) ask another computer (the **server**) for data or actions. Whenever you browse a site or call a web service, your client sends an HTTP *request* and the server answers with an HTTP *response*.
-
-An HTTP request consists of a **URL**—the address of the resource or endpoint you want—and an **HTTP method**, which tells the server what you’d like to do. The two most common methods are **GET** (to fetch data, like loading a webpage) and **POST** (to submit data, such as filling in a form). By combining the URL and method (e.g. `GET https://example.com/data`), the client makes its intentions clear.
-
-When the server receives that request, it processes whatever work is needed—retrieving files, querying a database, or running a service—and then sends back a response. Each response begins with a **status code** (a number indicating success or failure, such as **200 OK** for success or **404 Not Found** when something is missing) followed by the **body** containing the actual data or content. For webpages this is usually HTML; for data services (APIs), it’s often JSON (JavaScript Object Notation).
-
-This back-and-forth interaction is called the **request-response cycle**, and it’s entirely **stateless**—each request is handled on its own, with no memory of previous requests. That stateless design makes HTTP simple and highly scalable, allowing any client that speaks HTTP (from browsers to Python scripts) to interoperate with any server that understands HTTP. When you move on to APIs, you’ll leverage this same cycle to automate large-scale data retrieval and processing.
+This page goes a level deeper than the [Introduction to APIs](api-use.html). It assumes you've read that page and now want a slightly fuller picture of how the request-response cycle works, what REST is, and what other API styles exist.
 
 ## How APIs Work: Client-Server Interaction, Requests, and Responses
 
@@ -63,8 +55,6 @@ REST is the most common approach, but it’s not the only pattern you might enco
 * **WebSockets (Real-Time APIs):** A WebSocket provides a continuous two-way connection between client and server, allowing data to be sent in real time. This isn’t a request-response model; it’s more like an open channel. WebSockets are useful for applications like live chat, streaming data updates, or multiplayer games – anywhere you want instant, ongoing data flow. For instance, if you were tracking sentiment on a live stream of tweets, a WebSocket connection could stream new analyses continuously. This is more specialized, so we’ll stick to the request/response style in our work, but you might encounter WebSocket APIs in other contexts (e.g., real-time stock price feeds).
 
 For most data analysis tasks (like fetching data or sending data for analysis), you’ll be using **REST APIs**, as they cover the majority of use cases and are easier to get started with.
-
-Great, I’ll put together a conceptual overview of how API client libraries (especially in Python, with a mention of R) work, including when and why you’d use them, and how they simplify HTTP requests behind the scenes. I’ll be back shortly with the draft section you can add to your markdown.
 
 ## API Client Libraries
 

--- a/da-knowledge/api-use.qmd
+++ b/da-knowledge/api-use.qmd
@@ -9,6 +9,23 @@ Previously, we manually examined a sample of just 20 texts and tried using an LL
 
 Our baseline approach is for Python, but R is pretty similar (see below)
 
+## First, the architecture of the web: client, server, request, response
+
+Before talking about APIs, it helps to know the basic shape of how anything on the web talks to anything else. This is the foundation – APIs are just one specific use of it.
+
+Whenever you load a webpage, your browser (the **client**) sends a short message – a **request** – to another computer (the **server**) asking for something. The server does whatever work is needed and sends back a **response**: a status code (e.g. **200 OK** if it worked, **404 Not Found** if the thing isn't there) plus the actual content.
+
+Two pieces describe a request:
+
+- a **URL**, which is the address of what you want (e.g. `https://example.com/data`), and
+- an **HTTP method**, which says what you want to do with it. The two you'll see most are **GET** (fetch something) and **POST** (send something).
+
+That round trip – client sends request, server sends response – is the **request-response cycle**, and it's the same whether your browser is loading a news site or your Python script is asking an API for sentiment scores. Each request is **stateless**: the server doesn't remember the previous one, so each call has to carry everything it needs.
+
+Julia Evans has a nice short illustrated explainer: [How URLs work](https://wizardzines.com/comics/how-urls-work/), with a longer ["HTTP" zine](https://wizardzines.com/zines/http/) if you want to go deeper.
+
+Once you have this picture in your head, an API stops being mysterious: it's the same client, server, request, response – just with a machine on the client side instead of a person.
+
 ## What is an API?
 
 An **API (Application Programming Interface)** is like a **messenger** or **middleman** that lets two different programs talk to each other and exchange information. Instead of a person directly doing a task, you have one software program asking another program to do something on its behalf. A popular analogy is that an API is similar to a [**restaurant waiter**](https://www.youtube.com/watch?v=OVvTv9Hy91Q):
@@ -44,6 +61,46 @@ Most APIs require some form of **authentication** to ensure that only authorized
 
 Some services use more complex authentication (like OAuth tokens which have limited scope or expiration), but an API key is the fundamental concept to understand first. It’s your **access credential** for using the API.
 
+## You usually don't write the HTTP yourself: API libraries
+
+Most popular APIs ship a **client library** (sometimes called an SDK) for Python and other languages. A client library is a thin wrapper that hides the URL, the headers, the API key, and the JSON parsing behind ordinary function calls. You set things up once, then you call methods like you'd call any other Python function.
+
+Concretely, here's the same API call done two ways. First, the raw HTTP version – you build the URL, attach your key, send it, and parse JSON back:
+
+```python
+import os, requests
+
+resp = requests.post(
+    "https://api.openai.com/v1/responses",
+    headers={"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+    json={"model": "gpt-4o-mini", "input": "Is this review positive or negative?"},
+)
+text = resp.json()["output"][0]["content"][0]["text"]
+```
+
+Now the client-library version. Same task, but the library handles the URL, the auth header, and the JSON for you:
+
+```python
+from openai import OpenAI
+
+client = OpenAI()  # picks up OPENAI_API_KEY from your environment
+resp = client.responses.create(
+    model="gpt-4o-mini",
+    input="Is this review positive or negative?",
+)
+text = resp.output_text
+```
+
+The two versions hit the same endpoint and get the same answer. The library version is shorter, easier to read, and – more importantly – the library deals with edge cases (auth refreshes, retries, rate limits, response schema changes) so you don't have to.
+
+A few practical notes:
+
+- Major services have official Python libraries: **`openai`**, **`anthropic`** for LLMs; **`google-cloud-*`**, **`boto3`** (AWS), **`azure-*`** for cloud platforms; **`tweepy`** (X/Twitter), **`praw`** (Reddit), **`yfinance`**, **`fredapi`** for data sources.
+- You install them with `pip install <name>`. They use your API key from an environment variable so you never hard-code it.
+- When no client library exists, fall back to **`requests`** and call the HTTP endpoint directly. The result is the same; you just write a few more lines.
+
+For a worked LLM example end-to-end (loading a key, sending text, structured output, batching), see [Calling LLM APIs from Python](llm-api-python.html).
+
 ## Get an API
 
 Next, you can go and get an API key for an AI service. As a start a few dollars will be enough. Follow [instructions](get-ai-api-key.html)
@@ -56,11 +113,7 @@ Next, you can go and get an API key for an AI service. As a start a few dollars 
 
 ## What's different in R
 
-**Client libraries in other languages:** While our focus is on Python, other programming languages provide similar conveniences. 
-
-In R, packages like **`httr`** (for making HTTP requests) and **`jsonlite`** (for parsing JSON) are commonly used to work with web APIs. Many APIs also have R packages or wrappers that function like client libraries, letting you call the API in one or two lines of R code. 
-
-The core idea is the same: a client library abstracts the RESTful requests into native language functions. Regardless of language, using a client library means you can integrate an API into your data analysis or application with less hassle, letting you focus on interpreting results rather than the mechanics of HTTP.
+The picture in R is essentially the same. For raw HTTP, **`httr2`** (or the older `httr`) plus **`jsonlite`** play the role of `requests` in Python. For wrappers, many services have an R package – **`ellmer`** for LLMs, **`fredr`** for FRED, **`rtweet`** for X/Twitter, etc. The core idea doesn't change: a library abstracts the request-response mechanics into native R functions, so you focus on the analysis rather than the plumbing.
 
 ## Scaling Up with APIs: From 20 to 10,000 and Beyond
 


### PR DESCRIPTION
## Summary

Addresses two open issues on the API knowledge pages.

- **#3 (introduce HTTP architecture first)** — `da-knowledge/api-use.qmd` now opens with a short "client / server / request / response" primer before the API material, with links to Julia Evans' [How URLs work](https://wizardzines.com/comics/how-urls-work/) and the [HTTP zine](https://wizardzines.com/zines/http/) per @korenmiklos's suggestion. The deeper HTTP coverage stays available in `api-advanced.qmd`.
- **#4 (introduce API libraries)** — added a core "You usually don't write the HTTP yourself: API libraries" section to `api-use.qmd`. It shows the same call written with raw `requests` and with the `openai` SDK side-by-side, then lists common Python wrappers (`anthropic`, `boto3`, `tweepy`, `praw`, `yfinance`, `fredapi`, …). The R section is tightened to make the same point in R.
- Cleanup in `api-advanced.qmd`: dropped the now-duplicate HTTP intro and removed a stray AI-leftover paragraph; added a one-line preamble pointing back to the core page.

Closes #3.
Closes #4.

## Test plan

- [ ] `quarto preview` of `da-knowledge/api-use.qmd` renders without errors and reads top-to-bottom
- [ ] `quarto preview` of `da-knowledge/api-advanced.qmd` renders cleanly
- [ ] Cross-links between the two pages resolve in the rendered site